### PR TITLE
Fixing incorrect use of range loop variable in closure

### DIFF
--- a/explorer.go
+++ b/explorer.go
@@ -77,7 +77,7 @@ func (e *Explorer) updateBalancers(discovery Discovery) {
 	wg.Add(len(discovery.Balancers))
 
 	for _, b := range discovery.Balancers {
-		go func() {
+		go func(b Balancer) {
 			defer wg.Done()
 
 			err := b.update(e.name, discovery.Apps, state)
@@ -85,7 +85,7 @@ func (e *Explorer) updateBalancers(discovery Discovery) {
 				log.Printf("error updating state on %s: %s\n", b, err)
 				return
 			}
-		}()
+		}(b)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
I've found using `go vet` tool:

```
explorer.go:83: range variable b captured by func literal
explorer.go:85: range variable b captured by func literal
exit status 1
```

That error means that `update` method is invoked all times for the last balancer in the range. See more details about correct use of the range loop variables in closures in [faq](https://golang.org/doc/faq#closures_and_goroutines).

Fixing this with passing argument `b` to the closure function.
