### PR TITLE
labels: add port namespacing to zoidberg

### DIFF
--- a/application/labels.go
+++ b/application/labels.go
@@ -1,16 +1,25 @@
 package application
 
-import "strings"
+import (
+	"log"
+	"strconv"
+	"strings"
+)
 
-// metaFromLabels creates app labels from zoidberg prefixed labels
-func metaFromLabels(labels map[string]string) map[string]string {
-	r := map[string]string{}
-
+// parseLabels creates app labels from zoidberg prefixed labels
+func parseLabels(labels map[string]string) map[int]map[string]string {
+	r := make(map[int]map[string]string)
 	for k, v := range labels {
-		if strings.HasPrefix(k, "zoidberg_meta_") {
-			r[strings.TrimPrefix(k, "zoidberg_meta_")] = v
+		if strings.HasPrefix(k, "zoidberg_port_") {
+			k2 := strings.TrimPrefix(k, "zoidberg_port_")
+			k3 := strings.SplitN(k2, "_", 2)
+			if p, err := strconv.Atoi(k3[0]); err != nil || len(k3) != 2 {
+				log.Printf("Found unparsable tag: %s", k)
+				continue
+			} else {
+				r[p][k3[1]] = v
+			}
 		}
 	}
-
 	return r
 }

--- a/application/labels.go
+++ b/application/labels.go
@@ -14,9 +14,12 @@ func parseLabels(labels map[string]string) map[int]map[string]string {
 			k2 := strings.TrimPrefix(k, "zoidberg_port_")
 			k3 := strings.SplitN(k2, "_", 2)
 			if p, err := strconv.Atoi(k3[0]); err != nil || len(k3) != 2 {
-				log.Printf("Found unparsable tag: %s", k)
+				log.Printf("found unparsable tag: %s", k)
 				continue
 			} else {
+				if _, ok := r[p]; !ok {
+					r[p] = make(map[string]string)
+				}
 				r[p][k3[1]] = v
 			}
 		}

--- a/application/marathon.go
+++ b/application/marathon.go
@@ -35,8 +35,8 @@ func NewMarathonFinderFromFlags() (Finder, error) {
 
 // MarathonFinder represents a finder that finds apps in Marathon
 type MarathonFinder struct {
-	f *marathon.AppFetcher
-	b string
+	f        *marathon.AppFetcher
+	balancer string
 }
 
 // NewMarathonFinder creates a new Marathon Finder with
@@ -56,14 +56,14 @@ func NewMarathonFinder(u string, b string) (Finder, error) {
 	}
 
 	return &MarathonFinder{
-		f: f,
-		b: b,
+		f:        f,
+		balancer: b,
 	}, nil
 }
 
 // Apps returns our applications running on associated Marathon
 func (m *MarathonFinder) Apps() (Apps, error) {
-	ma, err := m.f.FetchApps("zoidberg_balanced_by", m.b)
+	ma, err := m.f.Apps()
 	if err != nil {
 		return nil, err
 	}
@@ -71,50 +71,60 @@ func (m *MarathonFinder) Apps() (Apps, error) {
 	apps := map[string]App{}
 
 	for _, a := range ma {
-		name := a.Labels["zoidberg_app_name"]
-		if name == "" {
-			log.Printf("app %s has no label zoidberg_app_name\n", a.ID)
-			continue
-		}
-
-		version := a.Labels["zoidberg_app_version"]
-		if version == "" {
-			version = "1"
-		}
-
-		app := apps[name]
-		if app.Name == "" {
-			app.Name = name
-			app.Servers = []Server{}
-			app.Meta = metaFromLabels(a.Labels)
-		}
-
-		for _, task := range a.Tasks {
-			healthy := true
-			for _, check := range task.HealthCheckResult {
-				if check == nil {
-					continue
-				}
-
-				if !check.Alive {
-					healthy = false
-					break
-				}
+		meta := parseLabels(a.Labels)
+		for port, labels := range meta {
+			if labels["balanced_by"] != m.balancer {
+				continue
 			}
-
-			if !healthy {
+			name := labels["app_name"]
+			if name == "" {
+				log.Printf("app %s has no label zoidberg_app_name\n", a.ID)
 				continue
 			}
 
-			app.Servers = append(app.Servers, Server{
-				Version: version,
-				Host:    task.Host,
-				Port:    task.Ports[0],
-				Ports:   task.Ports,
-			})
-		}
+			version := labels["app_version"]
+			if version == "" {
+				version = "1"
+			}
 
-		apps[name] = app
+			app := apps[name]
+			if app.Name == "" {
+				app.Name = name
+				app.Servers = []Server{}
+
+				// labels only come from the first task,
+				// this could lead to funny errors if there
+				// are multiple tasks with the same zoidberg_app_name
+				app.Meta = labels
+			}
+
+			for _, task := range a.Tasks {
+				healthy := true
+				for _, check := range task.HealthCheckResult {
+					if check == nil {
+						continue
+					}
+
+					if !check.Alive {
+						healthy = false
+						break
+					}
+				}
+
+				if !healthy {
+					continue
+				}
+
+				app.Servers = append(app.Servers, Server{
+					Version: version,
+					Host:    task.Host,
+					Port:    task.Ports[port],
+					Ports:   task.Ports,
+				})
+			}
+
+			apps[name] = app
+		}
 	}
 
 	return apps, nil

--- a/application/mesos.go
+++ b/application/mesos.go
@@ -69,18 +69,18 @@ func (m *MesosFinder) Apps() (Apps, error) {
 	for _, task := range tasks {
 		meta := parseLabels(task.Labels)
 
-		for port, tags := range meta {
-			if task.Labels["balanced_by"] != m.balancer {
+		for port, labels := range meta {
+			if labels["balanced_by"] != m.balancer {
 				continue
 			}
 
-			name := task.Labels["app_name"]
+			name := labels["app_name"]
 			if name == "" {
 				log.Printf("task %s has no label app_name\n", task.Name)
 				continue
 			}
 
-			version := task.Labels["app_version"]
+			version := labels["app_version"]
 			if version == "" {
 				version = "1"
 			}
@@ -89,11 +89,10 @@ func (m *MesosFinder) Apps() (Apps, error) {
 			if app.Name == "" {
 				app.Name = name
 				app.Servers = []Server{}
-
 				// labels only come from the first task,
 				// this could lead to funny errors if there
-				// are multiple tasks with the same zoidberg_app_name
-				app.Meta = tags
+				// are multiple tasks with the same zoidberg_port_X_app_name
+				app.Meta = labels
 			}
 
 			app.Servers = append(app.Servers, Server{

--- a/balancer/marathon.go
+++ b/balancer/marathon.go
@@ -63,7 +63,7 @@ func NewMarathonFinder(u string, b string) (*MarathonFinder, error) {
 
 // Balancers returns our load balancers running on associated Marathon
 func (m *MarathonFinder) Balancers() ([]Balancer, error) {
-	apps, err := m.f.FetchApps("zoidberg_balancer_for", m.b)
+	apps, err := m.f.FetchApps(map[string]string{"zoidberg_balancer_for": m.b})
 	if err != nil {
 		return nil, err
 	}

--- a/marathon/fetcher.go
+++ b/marathon/fetcher.go
@@ -26,7 +26,19 @@ func NewAppFetcher(u string) (*AppFetcher, error) {
 	}, nil
 }
 
-// FetchApps fetches apps with specific label set to specific value
+// Apps fetches all apps from marathon.
+func (a *AppFetcher) Apps() ([]marathon.Application, error) {
+	mv := url.Values{}
+	mv.Set("embed", "apps.tasks")
+	ma, err := a.m.Applications(mv)
+	if err != nil {
+		return nil, err
+	}
+
+	return ma.Apps, nil
+}
+
+// FetchApps fetches apps with specific label set to specific value.
 func (a *AppFetcher) FetchApps(labelKey string, labelValue string) ([]marathon.Application, error) {
 	mv := url.Values{}
 	mv.Set("embed", "apps.tasks")

--- a/marathon/fetcher.go
+++ b/marathon/fetcher.go
@@ -1,6 +1,7 @@
 package marathon
 
 import (
+	"fmt"
 	"net/url"
 
 	"github.com/gambol99/go-marathon"
@@ -26,23 +27,13 @@ func NewAppFetcher(u string) (*AppFetcher, error) {
 	}, nil
 }
 
-// Apps fetches all apps from marathon.
-func (a *AppFetcher) Apps() ([]marathon.Application, error) {
-	mv := url.Values{}
-	mv.Set("embed", "apps.tasks")
-	ma, err := a.m.Applications(mv)
-	if err != nil {
-		return nil, err
-	}
-
-	return ma.Apps, nil
-}
-
 // FetchApps fetches apps with specific label set to specific value.
-func (a *AppFetcher) FetchApps(labelKey string, labelValue string) ([]marathon.Application, error) {
+func (a *AppFetcher) FetchApps(labels map[string]string) ([]marathon.Application, error) {
 	mv := url.Values{}
 	mv.Set("embed", "apps.tasks")
-	mv.Set("label", labelKey+"=="+labelValue)
+	for k, v := range labels {
+		mv.Set("label", fmt.Sprintf("%s==%s", k, v))
+	}
 
 	ma, err := a.m.Applications(mv)
 	if err != nil {


### PR DESCRIPTION
This breaks everything.  I don't expect this to be a quick change after
reviewing the situation, but I think it provides a good starting point.
We have to decide how much we care about backwards compatability here
too.  It would probably be possible, at the cost of code complexity.

The idea I had was basically that each task could have multiple ports
balanced by separate balancers, so the balancers should just get a
fully-baked app from the zoidberg tag parsing.
